### PR TITLE
URL & Version to support QUELPA

### DIFF
--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -3,6 +3,8 @@
 ;; Copyright (C) 2019  Kien Nguyen
 
 ;; Author: kien.n.quang@gmail.com
+;; URL: https://github.com/kiennq/lsp-powershell
+;; Version: 0.1
 ;; Keywords: languages
 ;; Package-Requires: ((emacs "25.1") (lsp-mode "6.0") (dash) (s))
 


### PR DESCRIPTION
Any chance you could accept this PR so that QUELPA stops complaining? I don't use `straight.el` (as I'm using `doom-emacs`) - the lack of a version is currently causing any installation to fail.