### PR TITLE
Fix editor services download & make it cross-platform

### DIFF
--- a/lsp-pwsh.el
+++ b/lsp-pwsh.el
@@ -99,8 +99,7 @@ Must not nil.")
 (advice-add 'lsp-ui-sideline--extract-info :filter-return #'lsp-pwsh--filter-cr)
 
 ;;; Utils
-(defconst lsp-pwsh-unzip-script "powershell -noprofile -noninteractive \
--nologo -ex bypass Expand-Archive -path '%s' -dest '%s'"
+(defconst lsp-pwsh-unzip-script "%s -noprofile -noninteractive -nologo -ex bypass -command Expand-Archive -path '%s' -dest '%s'"
   "Powershell script to unzip vscode extension package file.")
 
 (defcustom lsp-pwsh-github-asset-url
@@ -114,7 +113,7 @@ Must not nil.")
   (let ((temp-file (make-temp-file "ext" nil ".zip")))
     (url-copy-file url temp-file 'overwrite)
     (if (file-exists-p dest) (delete-directory dest 'recursive))
-    (shell-command (format lsp-pwsh-unzip-script temp-file dest))))
+    (shell-command (format lsp-pwsh-unzip-script lsp-pwsh-exe temp-file dest))))
 
 (defun lsp-pwsh-setup (&optional forced)
   "Downloading PowerShellEditorServices to `lsp-pwsh-dir'.


### PR DESCRIPTION
Firstly, make it cross-platform by looking for either `pwsh` (PowerShell Core executable for Linux / macOS) or `powershell`.

Next I noticed the current implementation of `lsp-pwsh-setup` is broken for me as `url-copy-file` does not deal with the multiple redirects behind the latest github release download URL (and `url.el` in general seems to be quite unreliable).

Since the user will need PowerShell installed anyway to start the edit server, I thought it would be less hassle to use the tried and tested `Invoke-WebRequest` which handles all the redirects automatically.